### PR TITLE
feat: update cache every run

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,8 +36,10 @@ jobs:
         id: cache-cookie
         uses: actions/cache@v3
         with:
+          key: cookie-${{ steps.hash_usr.outputs.digest }}-${{github.run_id}}
+          restore-keys: |
+            cookie-${{ steps.hash_usr.outputs.digest }}
           path: env.cookie
-          key: cookie-${{ steps.hash_usr.outputs.digest }}
         
       - name: Run shopee collector
         run: node collect.js


### PR DESCRIPTION
According to the [official doc](https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache), add update feature in case of cookie expiration.